### PR TITLE
Refactor: Use instance type descriptor

### DIFF
--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -393,7 +393,7 @@ class TestDeepError(object):
                                       </building>""")
 
         with pytest.raises_regexp(XMLSerDesError,
-                                  'expected tag "colour" but got "size"',
+                                  'missing: colour.*unexpected: size',
                                   ['building', 'rooms', 'room[2]', 'chairs', 'chair[3]']):
             Building.from_xml(bad_xml, 'building')
 

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -343,7 +343,6 @@ class TestBadMethodUsage(object):
         ids=['wrong-n-children', 'wrong-tags', 'one-wrong-tag'])
     #
     def test_bad_ordered_dict(self, bad_dict_items, cmp_txt):
-        bad_dict = OrderedDict(bad_dict_items)
         with pytest.raises_regexp(XMLSerDesWrongChildrenError,
                                   'mismatched children: ' + cmp_txt,
                                   xpath=['Circle']):

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -343,13 +343,16 @@ class TestBadMethodUsage(object):
         ids=['wrong-n-children', 'wrong-tags', 'one-wrong-tag'])
     #
     def test_bad_ordered_dict(self, bad_dict_items, cmp_txt):
-        # Shouldn't occur in normal use because from_xml() checks on
-        # construction of the dictionary that tags are as expected.
         bad_dict = OrderedDict(bad_dict_items)
         with pytest.raises_regexp(XMLSerDesWrongChildrenError,
                                   'mismatched children: ' + cmp_txt,
-                                  xpath=[]):
-            Circle.from_xml_dict(bad_dict)
+                                  xpath=['Circle']):
+            bad_xml = etree.Element('Circle')
+            for k, v in bad_dict_items:
+                elt = etree.Element(k)
+                elt.text = str(v)
+                bad_xml.append(elt)
+            Circle.from_xml(bad_xml, 'Circle')
 
     def test_wrong_top_level_tag(self):
         bad_xml = etree.fromstring('<rectangle><width>1</width><height>2</height></rectangle>')

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -333,7 +333,7 @@ class TestBadMethodUsage(object):
             Rectangle.from_xml(bad_xml, 'rect')
 
     @pytest.mark.parametrize(
-        'bad_dict_items,cmp_txt',
+        'bad_tag_val_pairs,cmp_txt',
         [([('a', 1), ('b', 2), ('c', 3)],
           r'\[missing: radius, missing: colour, unexpected: a, unexpected: b, unexpected: c\]'),
          ([('a', 1), ('b', 2)],
@@ -342,12 +342,12 @@ class TestBadMethodUsage(object):
           r'\[as-expected: radius, missing: colour, unexpected: b\]')],
         ids=['wrong-n-children', 'wrong-tags', 'one-wrong-tag'])
     #
-    def test_bad_ordered_dict(self, bad_dict_items, cmp_txt):
+    def test_bad_child_elements(self, bad_tag_val_pairs, cmp_txt):
         with pytest.raises_regexp(XMLSerDesWrongChildrenError,
                                   'mismatched children: ' + cmp_txt,
                                   xpath=['Circle']):
             bad_xml = etree.Element('Circle')
-            for k, v in bad_dict_items:
+            for k, v in bad_tag_val_pairs:
                 elt = etree.Element(k)
                 elt.text = str(v)
                 bad_xml.append(elt)

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -97,12 +97,6 @@ class Rectangle(XMLSerializable):
     def __eq__(self, other):
         return self.width == other.width and self.height == other.height
 
-    @classmethod
-    def from_xml_dict(cls, dct, _xpath=[]):
-        if list(dct) != ['width', 'height']:
-            raise ValueError('wrong tags')
-        return cls(*dct.values())
-
 
 class TestRectangle(object):
     def test_equality(self):

--- a/tests/test_type_descriptors.py
+++ b/tests/test_type_descriptors.py
@@ -206,7 +206,7 @@ class TestInstanceTypes(object):
         td = X.Instance(Rectangle)
         bad_xml = etree.fromstring('<rect><a>42</a><b>100</b></rect>')
         with pytest.raises_regexp(XMLSerDesError,
-                                  'expected tag "width" but got "a"',
+                                  '.*missing: width.*unexpected: a',
                                   xpath=['rect']):
             td.extract_from(bad_xml, 'rect')
 
@@ -307,7 +307,7 @@ class TestNumpyRecordStructured(_TestNumpyBase):
           'mismatched children',
           ['rectangles', 'rect[3]']),
          ('<rect><wd>42</wd><ht>100</ht></rect>',
-          'expected tag "width" but got "wd"',
+          'missing: width.*unexpected: wd',
           ['rectangles', 'rect[1]'])],
         ids=['wrong-n-elts', 'wrong-n-elts-third-child', 'wrong-child-tag'])
     #

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -170,7 +170,10 @@ class XMLSerializableNamedTupleMeta(XMLSerializableMeta):
         namedtuple_cls = collections.namedtuple(cls_name,
                                                 list(xml_cls.slot_name_from_tag_name.values()))
 
+        # Can't add 'xml_type_descriptor' to 'direct_cls_dict' because the class
+        # must exist before we can make an Instance type-descriptor for it.
         final_cls = type.__new__(meta, cls_name, (namedtuple_cls, xml_cls), direct_cls_dict)
+        final_cls.xml_type_descriptor = Instance(final_cls)
         return final_cls
 
 

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -232,7 +232,8 @@ class XMLSerializableNamedTuple(six.with_metaclass(XMLSerializableNamedTupleMeta
     ShinyCircle(radius=42)
     >>> sc.radius
     42
-    >>> print(xmlserdes.utils.str_from_xml_elt(sc.as_xml()))
+    >>> sc_xml = sc.as_xml()
+    >>> print(xmlserdes.utils.str_from_xml_elt(sc_xml))
     <Circle><radius>42</radius></Circle>
 
     (Note that the tag in the XML is ``Circle`` and not ``ShinyCircle``.)

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -227,17 +227,3 @@ class XMLSerializableNamedTuple(six.with_metaclass(XMLSerializableNamedTupleMeta
 
     xml_default_tag = None
     xml_descriptor = []
-
-    @classmethod
-    def _verify_children(cls, ordered_dict, _xpath):
-        tags_got = list(ordered_dict.keys())
-        tags_exp = list(cls.slot_name_from_tag_name.keys())
-        if tags_got != tags_exp:
-            raise XMLSerDesWrongChildrenError(exp_tags=tags_exp,
-                                              got_tags=tags_got,
-                                              xpath=_xpath)
-
-    @classmethod
-    def from_xml_dict(cls, ordered_dict, _xpath=[]):
-        cls._verify_children(ordered_dict, _xpath)
-        return cls._make(ordered_dict.values())

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -237,6 +237,13 @@ class XMLSerializableNamedTuple(six.with_metaclass(XMLSerializableNamedTupleMeta
     <Circle><radius>42</radius></Circle>
 
     (Note that the tag in the XML is ``Circle`` and not ``ShinyCircle``.)
+
+    But extracting a ``ShinyCircle`` from an XML element works as
+    expected:
+
+    >>> sc_round_trip = ShinyCircle.from_xml(sc_xml, 'Circle')
+    >>> print(sc_round_trip)
+    ShinyCircle(radius=42)
     """
 
     xml_default_tag = None

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -170,7 +170,8 @@ class XMLSerializableNamedTupleMeta(XMLSerializableMeta):
         namedtuple_cls = collections.namedtuple(cls_name,
                                                 list(xml_cls.slot_name_from_tag_name.values()))
 
-        return type.__new__(meta, cls_name, (namedtuple_cls, xml_cls), direct_cls_dict)
+        final_cls = type.__new__(meta, cls_name, (namedtuple_cls, xml_cls), direct_cls_dict)
+        return final_cls
 
 
 class XMLSerializableNamedTuple(six.with_metaclass(XMLSerializableNamedTupleMeta,

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -101,16 +101,7 @@ class XMLSerializable(six.with_metaclass(XMLSerializableMeta)):
         is done by a class method ``from_xml_dict``, which the derived
         class must provide.
         """
-
-        _xpath = _xpath or [expected_tag]
-        if xml_elt.tag != expected_tag:
-            raise XMLSerDesError('expected tag "%s" but got "%s"'
-                                 % (expected_tag, xml_elt.tag),
-                                 xpath=_xpath[:-1])
-
-        ordered_dict = cls._ordered_dict_from_xml(xml_elt, _xpath)
-        # Might throw exception if class doesn't care about deserialization:
-        return cls.from_xml_dict(ordered_dict, _xpath)
+        return cls.xml_type_descriptor.extract_from(xml_elt, expected_tag, _xpath)
 
     @classmethod
     def _ordered_dict_from_xml(cls, xml_elt, _xpath):

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -56,6 +56,7 @@ class XMLSerializableMeta(type):
         cls_dict['slot_name_from_tag_name'] = meta.build_map_as_ordered_dict(xml_descriptor)
 
         cls = super(XMLSerializableMeta, meta).__new__(meta, cls_name, bases, cls_dict)
+        cls.xml_type_descriptor = Instance(cls)
 
         # Any further checks on cls here?
         return cls

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -82,7 +82,7 @@ class XMLSerializable(six.with_metaclass(XMLSerializableMeta)):
         """
 
         tag = tag or self.xml_default_tag
-        instance_td = Instance(self.__class__)  # TODO: Cache this t.d. in class?
+        instance_td = self.xml_type_descriptor
         return instance_td.xml_element(self, tag, [tag])
 
     def as_xml_str(self, tag=None, **kwargs):

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -97,9 +97,7 @@ class XMLSerializable(six.with_metaclass(XMLSerializableMeta)):
     def from_xml(cls, xml_elt, expected_tag, _xpath=[]):
         """
         Return a new instance of ``cls`` by deserializing the given XML
-        element, which must have the given expected tag.  The real work
-        is done by a class method ``from_xml_dict``, which the derived
-        class must provide.
+        element, which must have the given expected tag.
         """
         return cls.xml_type_descriptor.extract_from(xml_elt, expected_tag, _xpath)
 

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -101,20 +101,6 @@ class XMLSerializable(six.with_metaclass(XMLSerializableMeta)):
         """
         return cls.xml_type_descriptor.extract_from(xml_elt, expected_tag, _xpath)
 
-    @classmethod
-    def _ordered_dict_from_xml(cls, xml_elt, _xpath):
-        descr = cls.xml_descriptor
-
-        # Individual wrong tags will be caught later.
-        if len(xml_elt) != len(descr):
-            raise XMLSerDesWrongChildrenError(exp_tags=[e.tag for e in descr],
-                                              got_tags=[ch.tag for ch in xml_elt],
-                                              xpath=_xpath)
-
-        return collections.OrderedDict(
-            (child_elt.tag, descr_elt.extract_from(child_elt, _xpath + [child_elt.tag]))
-            for child_elt, descr_elt in zip(xml_elt, descr))
-
 
 class XMLSerializableNamedTupleMeta(XMLSerializableMeta):
     @staticmethod

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -523,9 +523,11 @@ class Instance(TypeDescriptor):
 
     def _extract_from(self, elt, expected_tag, _xpath):
         descr = self.xml_descriptor
-        if len(elt) != len(descr):
-            raise XMLSerDesWrongChildrenError(exp_tags=[e.tag for e in descr],
-                                              got_tags=[ch.tag for ch in elt],
+        exp_tags = [e.tag for e in descr]
+        got_tags = [ch.tag for ch in elt]
+        if got_tags != exp_tags:
+            raise XMLSerDesWrongChildrenError(exp_tags=exp_tags,
+                                              got_tags=got_tags,
                                               xpath=_xpath)
 
         ctor = self.constructor


### PR DESCRIPTION
The existing machinery which `XMLSerializable` uses to deserialize an instance from XML has considerable duplication with that used by the `Instance` type-descriptor.  This PR removes that duplication and simplifies the deserialization mechanism.

Summary of changes:
* Store an `Instance` type-descriptor in a class instance variable.
* Use it in `as_xml()` and `from_xml()`

This is a backward-incompatible change, in that currently classes have to provide a `from_xml_dict()` method.  The `XMLSerializableNamedTuple` implements this method; it's expected that most users will derive from this class, and so not have to provide their own `from_xml_dict()`.  As far as known, nobody is overriding `from_xml_dict()` or implementing it differently, so impact should be minimal.

@aldanor: Any comments would be appreciated.