### PR TITLE
Allow storage of data in XML attributes

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -12,9 +12,9 @@ jobs:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,27 @@
+name: Python package
+
+on: push
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install -r requirements.txt
+    - name: Install package
+      run: python setup.py install
+    - name: Run tests
+      run: pytest tests

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,6 @@ htmlcov/
 .junit/
 docs/build/
 build/
+dist/
+xml_serdes.egg-info/
 notes.txt

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ build/
 dist/
 xml_serdes.egg-info/
 notes.txt
+venv/

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -308,6 +308,18 @@ class TestNamedTupleDifferentTags(object):
         assert e1 == e
 
 
+class FruitSalad(XMLSerializableNamedTuple):
+    xml_descriptor = [('@n-apples', 'n_apples', int),
+                      ('put-in', 'container', str)]
+
+
+class TestNamedTupleAttributes(object):
+    def test_round_trip(self):
+        s = FruitSalad(7, 'bowl')
+        assert (str_from_xml_elt(s.as_xml())
+                == '<FruitSalad n-apples="7"><put-in>bowl</put-in></FruitSalad>')
+
+
 class TestBadNamedTupleConstruction(object):
     def build_bad_class_wrong_value_from_slot():
         class Foo(XMLSerializableNamedTuple):

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -476,6 +476,17 @@ class TestEnum(object):
         pd1 = PetDetails.from_xml(pd_xml, 'pet-details')
         assert pd1 == pd
 
+    def test_in_attribute(self):
+        # TODO: If tag-/slot-name starts with '@', strip from slot-name
+        class PetDetails(XMLSerializableNamedTuple):
+            xml_descriptor = [('@tp', 'type', self.Animal), ('@wt', 'weight', float)]
+
+        pd = PetDetails(self.Animal.Dog, 42.5)
+        pd_xml = pd.as_xml('pet-details')
+        assert str_from_xml_elt(pd_xml) == '<pet-details tp="Dog" wt="42.5"/>'
+        pd1 = PetDetails.from_xml(pd_xml, 'pet-details')
+        assert pd1 == pd
+
 
 class TestNumpyArraysIncludingEmpty:
     class HyperCube(XMLSerializableNamedTuple):

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -246,23 +246,23 @@ class TestNestedNamedTuple(object):
 
 class TestBadAttributeContents(object):
     def test_instance_attribute(self):
-        with pytest.raises_regexp(ValueError, 'tag "@circle" not valid'):
+        with pytest.raises(ValueError, match='tag "@circle" not valid'):
             class BadInstance(XMLSerializableNamedTuple):
                 xml_descriptor = [('@circle', Circle)]
 
     def test_list_attribute(self):
-        with pytest.raises_regexp(ValueError, 'tag "@circles" not valid'):
+        with pytest.raises(ValueError, match='tag "@circles" not valid'):
             class BadList(XMLSerializableNamedTuple):
                 xml_descriptor = [('@circles', [Circle, 'circle'])]
 
     def test_numpy_record_vector_attribute(self):
-        with pytest.raises_regexp(ValueError, 'tag "@dimensions" not valid'):
+        with pytest.raises(ValueError, match='tag "@dimensions" not valid'):
             dims_dtype = np.dtype([('wd', np.uint8), ('ht', np.uint8)])
             class BadList(XMLSerializableNamedTuple):
                 xml_descriptor = [('@dimensions', (np.ndarray, dims_dtype, 'dims'))]
 
     def test_dtype_scalar_attribute(self):
-        with pytest.raises_regexp(ValueError, 'tag "@dimensions" not valid'):
+        with pytest.raises(ValueError, match='tag "@dimensions" not valid'):
             dims_dtype = np.dtype([('wd', np.uint8), ('ht', np.uint8)])
             class BadList(XMLSerializableNamedTuple):
                 xml_descriptor = [('@dimensions', dims_dtype)]

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -265,8 +265,7 @@ class TestBadAttributeContents(object):
         with pytest.raises_regexp(ValueError, 'tag "@dimensions" not valid'):
             dims_dtype = np.dtype([('wd', np.uint8), ('ht', np.uint8)])
             class BadList(XMLSerializableNamedTuple):
-                # TODO: Provide 'terse' shortcut for DTypeScalar
-                xml_descriptor = [('@dimensions', DTypeScalar(dims_dtype))]
+                xml_descriptor = [('@dimensions', dims_dtype)]
 
 
 class RectangleCollection(XMLSerializableNamedTuple):

--- a/tests/test_intrusive.py
+++ b/tests/test_intrusive.py
@@ -456,14 +456,20 @@ class TestBadMetaclassUse(object):
 @pytest.mark.skipif(sys.version_info < (3, 4),
                     reason='requires Python 3.4 or higher')
 class TestEnum(object):
-    def test_round_trip(self):
+    try:
+        # Tests will only actually run under correct Python, so fine to
+        # ignore the ImportError if we don't find the 'enum' module at
+        # class-definition time.
         from enum import Enum
         Animal = Enum('Animal', 'Cat Dog Rabbit')
+    except ImportError:
+        pass
 
+    def test_round_trip(self):
         class PetDetails(XMLSerializableNamedTuple):
-            xml_descriptor = [('type', Animal), ('weight', float)]
+            xml_descriptor = [('type', self.Animal), ('weight', float)]
 
-        pd = PetDetails(Animal.Dog, 42.5)
+        pd = PetDetails(self.Animal.Dog, 42.5)
         pd_xml = pd.as_xml('pet-details')
         assert str_from_xml_elt(pd_xml) == ('<pet-details><type>Dog</type>'
                                             '<weight>42.5</weight></pet-details>')

--- a/tests/test_type_descriptors.py
+++ b/tests/test_type_descriptors.py
@@ -285,6 +285,21 @@ class TestNumpyAtomicConvenience(TestNumpyAtomic):
         self.td = X.NumpyVector(np.int32)
 
 
+class TestNumpyScalarDType(object):
+    def test_content(self):
+        colour_dtype = np.dtype([('red', np.uint8),
+                                 ('green', np.uint8),
+                                 ('blue', np.uint8)])
+        # The '[()]' indexing extracts scalar from 0-dim array:
+        colour = np.array((25, 50, 75), dtype=colour_dtype)[()]
+        td = make_TD(colour_dtype)
+        elt = td.xml_element(colour, 'colour')
+        assert XU.str_from_xml_elt(elt) == ('<colour>'
+                                            '<red>25</red>'
+                                            '<green>50</green>'
+                                            '<blue>75</blue></colour>')
+
+
 RectangleDType = np.dtype([('width', np.int32), ('height', np.int32)])
 
 RectanglePairDType = np.dtype([('big', RectangleDType), ('small', RectangleDType)])

--- a/tests/test_xmlnode.py
+++ b/tests/test_xmlnode.py
@@ -6,7 +6,7 @@ import xmlserdes.nodes as XN
 make_TD = X.TypeDescriptor.from_terse
 
 
-class TestBadAppend(object):
+class TestBadAttributeActions(object):
     @pytest.mark.parametrize(
         'err_fragment, tag',
         [('child', 'height'), ('attribute', '@height')])

--- a/tests/test_xmlnode.py
+++ b/tests/test_xmlnode.py
@@ -13,18 +13,18 @@ class TestBadAttributeActions(object):
     #
     def test_append_to_attribute(self, err_fragment, tag):
         n = XN.make_XMLNode('@weight', '23 stone')
-        with pytest.raises_regexp(ValueError, 'cannot append {0}'.format(err_fragment)):
+        with pytest.raises(ValueError, match='cannot append {0}'.format(err_fragment)):
             ch = XN.make_XMLNode(tag, '6 feet')
             ch.append_to(n)
 
     def test_attribute_no_text(self):
-        with pytest.raises_regexp(ValueError,
-                                  'expected "text" when constructing XMLAttributeNode'):
+        with pytest.raises(ValueError,
+                           match='expected "text" when constructing XMLAttributeNode'):
             n = XN.make_XMLNode('@weight')
 
 
 class TestBadElement(object):
     def test_request_element_when_attribute(self):
         td = make_TD(int)
-        with pytest.raises_regexp(ValueError, 'expected element but got attribute'):
+        with pytest.raises(ValueError, match='expected element but got attribute'):
             td.xml_element(42, '@height')

--- a/tests/test_xmlnode.py
+++ b/tests/test_xmlnode.py
@@ -1,0 +1,12 @@
+import pytest
+
+import xmlserdes as X
+
+make_TD = X.TypeDescriptor.from_terse
+
+
+class TestBadElement(object):
+    def test_request_element_when_attribute(self):
+        td = make_TD(int)
+        with pytest.raises_regexp(ValueError, 'expected element but got attribute'):
+            td.xml_element(42, '@height')

--- a/tests/test_xmlnode.py
+++ b/tests/test_xmlnode.py
@@ -17,6 +17,11 @@ class TestBadAttributeActions(object):
             ch = XN.make_XMLNode(tag, '6 feet')
             ch.append_to(n)
 
+    def test_attribute_no_text(self):
+        with pytest.raises_regexp(ValueError,
+                                  'expected "text" when constructing XMLAttributeNode'):
+            n = XN.make_XMLNode('@weight')
+
 
 class TestBadElement(object):
     def test_request_element_when_attribute(self):

--- a/tests/test_xmlnode.py
+++ b/tests/test_xmlnode.py
@@ -1,8 +1,21 @@
 import pytest
 
 import xmlserdes as X
+import xmlserdes.nodes as XN
 
 make_TD = X.TypeDescriptor.from_terse
+
+
+class TestBadAppend(object):
+    @pytest.mark.parametrize(
+        'err_fragment, tag',
+        [('child', 'height'), ('attribute', '@height')])
+    #
+    def test_append_to_attribute(self, err_fragment, tag):
+        n = XN.make_XMLNode('@weight', '23 stone')
+        with pytest.raises_regexp(ValueError, 'cannot append {0}'.format(err_fragment)):
+            ch = XN.make_XMLNode(tag, '6 feet')
+            ch.append_to(n)
 
 
 class TestBadElement(object):

--- a/xmlserdes/element_descriptor.py
+++ b/xmlserdes/element_descriptor.py
@@ -92,6 +92,9 @@ class ElementDescriptor(collections.namedtuple('_ElementDescriptor',
         """
         return self.type_descr.xml_element(self.value_from(obj), self.tag, _xpath)
 
+    def xml_node(self, obj, _xpath=[]):
+        return self.type_descr.xml_node(self.value_from(obj), self.tag, _xpath)
+
     def extract_from(self, elt, _xpath=[]):
         """
         Deserialize, from an XML element, a value of the relevant type.

--- a/xmlserdes/element_descriptor.py
+++ b/xmlserdes/element_descriptor.py
@@ -30,6 +30,13 @@ class ElementDescriptor(collections.namedtuple('_ElementDescriptor',
     :meth:`xmlserdes.ElementDescriptor.new_from_tuple` method.
     """
 
+    def __new__(cls, *args, **kwargs):
+        elt_descr = super(ElementDescriptor, cls).__new__(cls, *args, **kwargs)
+        if not elt_descr.type_descr.tag_is_valid(elt_descr.tag):
+            raise ValueError('tag "{0}" not valid for complex type-descriptor'
+                             .format(elt_descr.tag))
+        return elt_descr
+
     @classmethod
     def _ensure_TypeDescriptor(cls, obj):
         """

--- a/xmlserdes/element_descriptor.py
+++ b/xmlserdes/element_descriptor.py
@@ -64,7 +64,8 @@ class ElementDescriptor(collections.namedtuple('_ElementDescriptor',
 
         if len(tup) == 2:
             tag, td = tup
-            return cls(tag, operator.attrgetter(tag), tag, cls._ensure_TypeDescriptor(td))
+            slot = (tag[1:] if tag[0] == '@' else tag)
+            return cls(tag, operator.attrgetter(slot), slot, cls._ensure_TypeDescriptor(td))
         elif len(tup) == 3:
             tag, vf, td = tup
             vslot = None

--- a/xmlserdes/intrusive.py
+++ b/xmlserdes/intrusive.py
@@ -171,6 +171,18 @@ class XMLSerializableNamedTuple(six.with_metaclass(XMLSerializableNamedTupleMeta
     >>> print(xmlserdes.utils.str_from_xml_elt(r.as_xml()))
     <rect><wd>10</wd><ht>20</ht></rect>
 
+    If a field's name specifies that the its value is to be stored in an
+    XML attribute (by starting with the ``'@'`` character), then the
+    field name of the class removes that ``'@'``:
+
+    >>> class Ellipse(xmlserdes.XMLSerializableNamedTuple):
+    ...     xml_default_tag = 'oval'
+    ...     xml_descriptor = [('@major', int), ('@minor', int),
+    ...                       ('colour', str)]
+    >>> e = Ellipse(8, 5, 'red')
+    >>> print(xmlserdes.utils.str_from_xml_elt(e.as_xml()))
+    <oval major="8" minor="5"><colour>red</colour></oval>
+
     If class has no ``xml_default_tag`` attribute, it is created with
     value equal to the class name:
 

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -10,6 +10,9 @@ class XMLElementNode(object):
     def append_child(self, ch):
         self.elt.append(ch)
 
+    def append_to(self, parent_elt):
+        parent_elt.append_child(self.elt)
+
 
 def make_XMLNode(tag, *args):
     return XMLElementNode(tag, *args)

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -14,5 +14,13 @@ class XMLElementNode(object):
         parent_elt.append_child(self.elt)
 
 
+class XMLAttributeNode(object):
+    def __init__(self, tag, text=None):
+        if text is None:
+            raise ValueError('expected "text" when constructing XMLAttributeNode')
+        self.tag = tag
+        self.text = text
+
+
 def make_XMLNode(tag, *args):
     return XMLElementNode(tag, *args)

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -10,6 +10,9 @@ class XMLElementNode(object):
     def append_child(self, ch):
         self.elt.append(ch)
 
+    def append_attrib(self, ch):
+        self.elt.attrib[ch.tag] = ch.text
+
     def append_to(self, parent_elt):
         parent_elt.append_child(self.elt)
 
@@ -23,6 +26,9 @@ class XMLAttributeNode(object):
 
     def append_child(self, ch):
         raise ValueError('cannot append child to XMLAttributeNode')
+
+    def append_attrib(self, ch):
+        raise ValueError('cannot append attribute to XMLAttributeNode')
 
     def append_to(self, parent_elt):
         parent_elt.append_attrib(self)

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -6,3 +6,7 @@ class XMLElementNode(object):
         elt = etree.Element(tag)
         elt.text = text
         self.elt = elt
+
+
+def make_XMLNode(tag, *args):
+    return XMLElementNode(tag, *args)

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -21,6 +21,9 @@ class XMLAttributeNode(object):
         self.tag = tag
         self.text = text
 
+    def append_child(self, ch):
+        raise ValueError('cannot append child to XMLAttributeNode')
+
 
 def make_XMLNode(tag, *args):
     return XMLElementNode(tag, *args)

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -1,0 +1,8 @@
+from lxml import etree
+
+
+class XMLElementNode(object):
+    def __init__(self, tag, text=None):
+        elt = etree.Element(tag)
+        elt.text = text
+        self.elt = elt

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -7,6 +7,9 @@ class XMLElementNode(object):
         elt.text = text
         self.elt = elt
 
+    def append_child(self, ch):
+        self.elt.append(ch)
+
 
 def make_XMLNode(tag, *args):
     return XMLElementNode(tag, *args)

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -24,6 +24,9 @@ class XMLAttributeNode(object):
     def append_child(self, ch):
         raise ValueError('cannot append child to XMLAttributeNode')
 
+    def append_to(self, parent_elt):
+        parent_elt.append_attrib(self)
+
 
 def make_XMLNode(tag, *args):
     return XMLElementNode(tag, *args)

--- a/xmlserdes/nodes.py
+++ b/xmlserdes/nodes.py
@@ -35,4 +35,7 @@ class XMLAttributeNode(object):
 
 
 def make_XMLNode(tag, *args):
-    return XMLElementNode(tag, *args)
+    if tag[0] == '@':
+        return XMLAttributeNode(tag[1:], *args)
+    else:
+        return XMLElementNode(tag, *args)

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -542,13 +542,16 @@ class Instance(TypeDescriptor):
                                               got_tags=got_tags,
                                               xpath=_xpath)
 
+    def _ctor_args(self, elt, _xpath):
+        return [descr_elt.extract_from(child_elt, _xpath + [child_elt.tag])
+                for child_elt, descr_elt in zip(elt, self.xml_descriptor)]
+
     def _extract_from(self, elt, _xpath):
         descr = self.xml_descriptor
         self._verify_children(elt, _xpath)
 
         ctor = self.constructor
-        ctor_args = [descr_elt.extract_from(child_elt, _xpath + [child_elt.tag])
-                     for child_elt, descr_elt in zip(elt, descr)]
+        ctor_args = self._ctor_args(elt, _xpath)
 
         return ctor(*ctor_args)
 

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -31,6 +31,14 @@ class TypeDescriptor(six.with_metaclass(ABCMeta)):
     - :func:`extract_from` --- extract an object of the correct type
       from a given XML element.
 
+    The following static method is also available:
+
+    - :func:`tag_is_valid` --- return ``True`` or ``False`` according to
+      whether the given tag is valid for this type-descriptor.  For
+      example, lists cannot be stored in attributes, and so a tag
+      beginning with ``'@'`` is not valid for a type-descriptor storing
+      a list.
+
     This base type is not useful.  Concrete derived types are:
 
     - :class:`xmlserdes.Atomic` --- fundamental type such as integer or string.
@@ -254,6 +262,10 @@ class TypeDescriptor(six.with_metaclass(ABCMeta)):
         """
         Return either an xml element or an xml attribute.
         """
+
+    @staticmethod
+    def tag_is_valid(tag):
+        return True
 
     def extract_from(self, elt, expected_tag, _xpath=[]):
         """

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -259,10 +259,10 @@ class TypeDescriptor(six.with_metaclass(ABCMeta)):
         """
         _xpath = _xpath or [expected_tag]
         self.verify_tag(elt, expected_tag, _xpath)
-        return self._extract_from(elt, expected_tag, _xpath)
+        return self._extract_from(elt, _xpath)
 
     @abstractmethod  # pragma: no cover
-    def _extract_from(self, elt, expected_tag, _xpath):
+    def _extract_from(self, elt, _xpath):
         """
         Internal method implementing extract_from() under the assumption
         that the tag is as expected.
@@ -310,7 +310,7 @@ class Atomic(TypeDescriptor):
         elt.text = str(obj)
         return elt
 
-    def _extract_from(self, elt, expected_tag, _xpath):
+    def _extract_from(self, elt, _xpath):
         try:
             return self.inner_type(elt.text)
         except Exception as err:
@@ -359,7 +359,7 @@ class AtomicBool(TypeDescriptor):
                                  xpath=_xpath)
         return elt
 
-    def _extract_from(self, elt, expected_tag, _xpath):
+    def _extract_from(self, elt, _xpath):
         text = elt.text
         if text == 'true':
             return True
@@ -406,7 +406,7 @@ if HAVE_ENUM:
             elt.text = obj.name
             return elt
 
-        def _extract_from(self, elt, expected_tag, _xpath):
+        def _extract_from(self, elt, _xpath):
             try:
                 return self.enum_type[elt.text]
             except KeyError:
@@ -465,7 +465,7 @@ class List(TypeDescriptor):
         # '+1' is to convert to xpath's 1-based indexing:
         return '%s[%d]' % (self.contained_tag, (i_0b + 1))
 
-    def _extract_from(self, elt, expected_tag, _xpath):
+    def _extract_from(self, elt, _xpath):
         return [self.contained_descriptor.extract_from(child_elt, self.contained_tag,
                                                        _xpath + [self.child_xpath_component(i)])
                 for i, child_elt in enumerate(elt)]
@@ -521,7 +521,7 @@ class Instance(TypeDescriptor):
             elt.append(child_elt)
         return elt
 
-    def _extract_from(self, elt, expected_tag, _xpath):
+    def _extract_from(self, elt, _xpath):
         descr = self.xml_descriptor
         exp_tags = [e.tag for e in descr]
         got_tags = [ch.tag for ch in elt]
@@ -587,7 +587,7 @@ class NumpyAtomicVector(TypeDescriptor, NumpyValidityAssertionMixin):
         elt.text = ','.join(map(repr, obj))
         return elt
 
-    def _extract_from(self, elt, expected_tag, _xpath):
+    def _extract_from(self, elt, _xpath):
         elt_text = elt.text or ''
         raw_s_elts = elt_text.split(',')
         # A special case is when elt.text is the empty string:
@@ -809,8 +809,8 @@ class NumpyRecordVectorStructured(List, NumpyValidityAssertionMixin):
         self.assert_valid(obj, np.ndarray, 'ndarray', 1, _xpath)
         return List.xml_element(self, obj, tag, _xpath)
 
-    def _extract_from(self, elt, expected_tag, _xpath):
-        elts = List._extract_from(self, elt, expected_tag, _xpath)
+    def _extract_from(self, elt, _xpath):
+        elts = List._extract_from(self, elt, _xpath)
         return np.array(elts, dtype=self.dtype)
 
 

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -231,7 +231,6 @@ class TypeDescriptor(six.with_metaclass(ABCMeta)):
                                  % (expected_tag, elt.tag),
                                  xpath=_xpath[:-1])
 
-    @abstractmethod  # pragma: no cover
     def xml_element(self, obj, tag, _xpath=[]):
         """
         Return an XML element, with the given tag, corresponding to the
@@ -244,6 +243,10 @@ class TypeDescriptor(six.with_metaclass(ABCMeta)):
 
         See examples under subclasses of :class:`xmlserdes.TypeDescriptor` for details.
         """
+        nd = self.xml_node(obj, tag, _xpath)
+        if not isinstance(nd, XMLElementNode):
+            raise XMLSerDesError('expected element but got attribute', xpath=_xpath)
+        return nd.elt
 
     @abstractmethod  # pragma: no cover
     def xml_node(self, obj, tag, _xpath=[]):

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -245,6 +245,12 @@ class TypeDescriptor(six.with_metaclass(ABCMeta)):
         See examples under subclasses of :class:`xmlserdes.TypeDescriptor` for details.
         """
 
+    @abstractmethod  # pragma: no cover
+    def xml_node(self, obj, tag, _xpath=[]):
+        """
+        Return either an xml element or an xml attribute.
+        """
+
     def extract_from(self, elt, expected_tag, _xpath=[]):
         """
         Extract and return an object from the given XML element.  The

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -7,6 +7,7 @@ from lxml import etree
 
 import xmlserdes
 from xmlserdes.errors import XMLSerDesError, XMLSerDesWrongChildrenError
+from xmlserdes.nodes import XMLElementNode, make_XMLNode
 
 import collections  # noqa
 
@@ -314,10 +315,8 @@ class Atomic(TypeDescriptor):
     def __init__(self, inner_type):
         self.inner_type = inner_type
 
-    def xml_element(self, obj, tag, _xpath=[]):
-        elt = etree.Element(tag)
-        elt.text = str(obj)
-        return elt
+    def xml_node(self, obj, tag, _xpath=[]):
+        return make_XMLNode(tag, str(obj))
 
     def _extract_from(self, elt, _xpath):
         try:
@@ -357,16 +356,15 @@ class AtomicBool(TypeDescriptor):
     xmlserdes.errors.XMLSerDesError: expected True or False but got "42" for bool at /
     """
 
-    def xml_element(self, obj, tag, _xpath=[]):
-        elt = etree.Element(tag)
+    def xml_node(self, obj, tag, _xpath=[]):
         if obj is True:
-            elt.text = 'true'
+            text = 'true'
         elif obj is False:
-            elt.text = 'false'
+            text = 'false'
         else:
             raise XMLSerDesError('expected True or False but got "%s" for bool' % obj,
                                  xpath=_xpath)
-        return elt
+        return make_XMLNode(tag, text)
 
     def _extract_from(self, elt, _xpath):
         text = elt.text
@@ -408,12 +406,10 @@ if HAVE_ENUM:
                 raise TypeError('expected Enum-derived type')
             self.enum_type = enum_type
 
-        def xml_element(self, obj, tag, _xpath=[]):
+        def xml_node(self, obj, tag, _xpath=[]):
             if not isinstance(obj, self.enum_type):
                 raise ValueError('expected instance of %.100s' % str(self.enum_type))
-            elt = etree.Element(tag)
-            elt.text = obj.name
-            return elt
+            return make_XMLNode(tag, obj.name)
 
         def _extract_from(self, elt, _xpath):
             try:
@@ -461,13 +457,14 @@ class List(TypeDescriptor):
         self.contained_descriptor = contained_descriptor
         self.contained_tag = contained_tag
 
-    def xml_element(self, obj, tag, _xpath=[]):
-        elt = etree.Element(tag)
+    def xml_node(self, obj, tag, _xpath=[]):
+        elt = XMLElementNode(tag)
         for i, obj_elt in enumerate(obj):
-            elt.append(self.contained_descriptor.xml_element(
+            child = self.contained_descriptor.xml_node(
                 obj_elt,
                 self.contained_tag,
-                _xpath + [self.child_xpath_component(i)]))
+                _xpath + [self.child_xpath_component(i)])
+            child.append_to(elt)
         return elt
 
     def child_xpath_component(self, i_0b):
@@ -523,12 +520,12 @@ class Instance(TypeDescriptor):
         self.xml_descriptor = cls.xml_descriptor
         self.constructor = cls
 
-    def xml_element(self, obj, tag, _xpath=[]):
-        elt = etree.Element(tag)
+    def xml_node(self, obj, tag, _xpath=[]):
+        nd = XMLElementNode(tag)
         for child in self.xml_descriptor:
-            child_elt = child.xml_element(obj, _xpath + [child.tag])
-            elt.append(child_elt)
-        return elt
+            child_nd = child.xml_node(obj, _xpath + [child.tag])
+            child_nd.append_to(nd)
+        return nd
 
     def _extract_from(self, elt, _xpath):
         descr = self.xml_descriptor
@@ -590,11 +587,9 @@ class NumpyAtomicVector(TypeDescriptor, NumpyValidityAssertionMixin):
     def __init__(self, dtype):
         self.dtype = dtype
 
-    def xml_element(self, obj, tag, _xpath=[]):
+    def xml_node(self, obj, tag, _xpath=[]):
         self.assert_valid(obj, np.ndarray, 'ndarray', 1, _xpath)
-        elt = etree.Element(tag)
-        elt.text = ','.join(map(repr, obj))
-        return elt
+        return make_XMLNode(tag, ','.join(map(repr, obj)))
 
     def _extract_from(self, elt, _xpath):
         elt_text = elt.text or ''
@@ -699,9 +694,9 @@ class DTypeScalar(Instance, NumpyValidityAssertionMixin):
             for nm in dtype.names
         ]
 
-    def xml_element(self, obj, tag, _xpath=[]):
+    def xml_node(self, obj, tag, _xpath=[]):
         self.assert_valid(obj, np.void, 'numpy scalar', 0, _xpath)
-        return Instance.xml_element(self, obj, tag, _xpath)
+        return Instance.xml_node(self, obj, tag, _xpath)
 
     def constructor(self, *args):
         return np.array(args, dtype=self.dtype)
@@ -814,9 +809,9 @@ class NumpyRecordVectorStructured(List, NumpyValidityAssertionMixin):
         self.dtype = dtype
         List.__init__(self, DTypeScalar(dtype), contained_tag)
 
-    def xml_element(self, obj, tag, _xpath=[]):
+    def xml_node(self, obj, tag, _xpath=[]):
         self.assert_valid(obj, np.ndarray, 'ndarray', 1, _xpath)
-        return List.xml_element(self, obj, tag, _xpath)
+        return List.xml_node(self, obj, tag, _xpath)
 
     def _extract_from(self, elt, _xpath):
         elts = List._extract_from(self, elt, _xpath)

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -544,12 +544,7 @@ class Instance(TypeDescriptor):
 
     def _extract_from(self, elt, _xpath):
         descr = self.xml_descriptor
-        exp_tags = self.expected_tags
-        got_tags = [ch.tag for ch in elt]
-        if got_tags != exp_tags:
-            raise XMLSerDesWrongChildrenError(exp_tags=exp_tags,
-                                              got_tags=got_tags,
-                                              xpath=_xpath)
+        self._verify_children(elt, _xpath)
 
         ctor = self.constructor
         ctor_args = [descr_elt.extract_from(child_elt, _xpath + [child_elt.tag])

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -520,6 +520,7 @@ class Instance(TypeDescriptor):
             raise ValueError('class "%s" has no xml_descriptor' % cls.__name__)
 
         self.xml_descriptor = cls.xml_descriptor
+        self.expected_tags = self._canonical_tags_list(self.xml_descriptor)
         self.constructor = cls
 
     def xml_node(self, obj, tag, _xpath=[]):
@@ -535,7 +536,7 @@ class Instance(TypeDescriptor):
 
     def _extract_from(self, elt, _xpath):
         descr = self.xml_descriptor
-        exp_tags = [e.tag for e in descr]
+        exp_tags = self.expected_tags
         got_tags = [ch.tag for ch in elt]
         if got_tags != exp_tags:
             raise XMLSerDesWrongChildrenError(exp_tags=exp_tags,

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -534,6 +534,14 @@ class Instance(TypeDescriptor):
     def _canonical_tags_list(descr):
         return [e.tag for e in descr]
 
+    def _verify_children(self, elt, _xpath):
+        got_tags = [ch.tag for ch in elt]
+        exp_tags = self.expected_tags
+        if got_tags != exp_tags:
+            raise XMLSerDesWrongChildrenError(exp_tags=exp_tags,
+                                              got_tags=got_tags,
+                                              xpath=_xpath)
+
     def _extract_from(self, elt, _xpath):
         descr = self.xml_descriptor
         exp_tags = self.expected_tags

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -547,13 +547,8 @@ class Instance(TypeDescriptor):
                 for child_elt, descr_elt in zip(elt, self.xml_descriptor)]
 
     def _extract_from(self, elt, _xpath):
-        descr = self.xml_descriptor
         self._verify_children(elt, _xpath)
-
-        ctor = self.constructor
-        ctor_args = self._ctor_args(elt, _xpath)
-
-        return ctor(*ctor_args)
+        return self.constructor(*self._ctor_args(elt, _xpath))
 
 
 class NumpyValidityAssertionMixin(object):

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -199,6 +199,9 @@ class TypeDescriptor(six.with_metaclass(ABCMeta)):
                     'list descriptor: expected 1 or 2 elements but got %d' % len(descr))
             return List(cls.from_terse(contained_descr), tag)
 
+        if isinstance(descr, np.dtype):
+            return DTypeScalar(descr)
+
         if isinstance(descr, tuple):
             if len(descr) == 0:
                 raise ValueError('empty tuple descriptor')

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -700,6 +700,7 @@ class DTypeScalar(Instance, NumpyValidityAssertionMixin):
             )
             for nm in dtype.names
         ]
+        self.expected_tags = [e.tag for e in self.xml_descriptor]
 
     def xml_node(self, obj, tag, _xpath=[]):
         self.assert_valid(obj, np.void, 'numpy scalar', 0, _xpath)

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -469,6 +469,10 @@ class List(TypeDescriptor):
         self.contained_descriptor = contained_descriptor
         self.contained_tag = contained_tag
 
+    @staticmethod
+    def tag_is_valid(tag):
+        return tag[0] != '@'
+
     def xml_node(self, obj, tag, _xpath=[]):
         # TODO: Ensure tag does not start with '@', as early as possible.
         elt = XMLElementNode(tag)
@@ -534,6 +538,10 @@ class Instance(TypeDescriptor):
         self.xml_descriptor = cls.xml_descriptor
         self.expected_tags = self._canonical_tags_list(self.xml_descriptor)
         self.constructor = cls
+
+    @staticmethod
+    def tag_is_valid(tag):
+        return tag[0] != '@'
 
     def xml_node(self, obj, tag, _xpath=[]):
         nd = XMLElementNode(tag)
@@ -726,6 +734,10 @@ class DTypeScalar(Instance, NumpyValidityAssertionMixin):
         ]
         self.expected_tags = [e.tag for e in self.xml_descriptor]
 
+    @staticmethod
+    def tag_is_valid(tag):
+        return tag[0] != '@'
+
     def xml_node(self, obj, tag, _xpath=[]):
         self.assert_valid(obj, np.void, 'numpy scalar', 0, _xpath)
         return Instance.xml_node(self, obj, tag, _xpath)
@@ -840,6 +852,10 @@ class NumpyRecordVectorStructured(List, NumpyValidityAssertionMixin):
     def __init__(self, dtype, contained_tag):
         self.dtype = dtype
         List.__init__(self, DTypeScalar(dtype), contained_tag)
+
+    @staticmethod
+    def tag_is_valid(tag):
+        return tag[0] != '@'
 
     def xml_node(self, obj, tag, _xpath=[]):
         self.assert_valid(obj, np.ndarray, 'ndarray', 1, _xpath)

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -529,6 +529,10 @@ class Instance(TypeDescriptor):
             child_nd.append_to(nd)
         return nd
 
+    @staticmethod
+    def _canonical_tags_list(descr):
+        return [e.tag for e in descr]
+
     def _extract_from(self, elt, _xpath):
         descr = self.xml_descriptor
         exp_tags = [e.tag for e in descr]

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -538,7 +538,8 @@ class Instance(TypeDescriptor):
         return attrib_tags + child_tags
 
     def _verify_children(self, elt, _xpath):
-        got_tags = [ch.tag for ch in elt]
+        got_tags = (['@' + tag for tag in sorted(elt.attrib.keys())]
+                    + [ch.tag for ch in elt])
         exp_tags = self.expected_tags
         if got_tags != exp_tags:
             raise XMLSerDesWrongChildrenError(exp_tags=exp_tags,

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -532,7 +532,10 @@ class Instance(TypeDescriptor):
 
     @staticmethod
     def _canonical_tags_list(descr):
-        return [e.tag for e in descr]
+        all_tags = [e.tag for e in descr]
+        attrib_tags = sorted(t for t in all_tags if t[0] == '@')
+        child_tags = [t for t in all_tags if t[0] != '@']
+        return attrib_tags + child_tags
 
     def _verify_children(self, elt, _xpath):
         got_tags = [ch.tag for ch in elt]

--- a/xmlserdes/type_descriptors.py
+++ b/xmlserdes/type_descriptors.py
@@ -458,6 +458,7 @@ class List(TypeDescriptor):
         self.contained_tag = contained_tag
 
     def xml_node(self, obj, tag, _xpath=[]):
+        # TODO: Ensure tag does not start with '@', as early as possible.
         elt = XMLElementNode(tag)
         for i, obj_elt in enumerate(obj):
             child = self.contained_descriptor.xml_node(
@@ -472,6 +473,7 @@ class List(TypeDescriptor):
         return '%s[%d]' % (self.contained_tag, (i_0b + 1))
 
     def _extract_from(self, elt, _xpath):
+        # TODO: Ensure no attributes in elt.
         return [self.contained_descriptor.extract_from(child_elt, self.contained_tag,
                                                        _xpath + [self.child_xpath_component(i)])
                 for i, child_elt in enumerate(elt)]


### PR DESCRIPTION
For 'simple' data, allow storage in XML attributes.  This is achieved by specifying a tag name starting with '@'.  For example, with

``` python
class Ellipse(xmlserdes.XMLSerializableNamedTuple):
    xml_default_tag = 'oval'
    xml_descriptor = [('@major', int), ('@minor', int),('colour', str)]
e = Ellipse(8, 5, 'red')
```

the object `e` would serialize as

``` xml
<oval major="8" minor="5"><colour>red</colour></oval>
```

@aldanor &mdash; comments welcome.
